### PR TITLE
API-GW Allow-Headers for OPTION calls

### DIFF
--- a/SAMTemplate.yaml
+++ b/SAMTemplate.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: "AWS::Serverless-2016-10-31"
-Description: CloudeeCMS Backend Auto Deployment 2023-06-06
+Description: CloudeeCMS Backend Auto Deployment 2024-01-24
 Parameters:
   AdminBucket:
     Type: String
@@ -164,7 +164,7 @@ Resources:
       BinaryMediaTypes:
         - multipart~1form-data
       Cors:
-        AllowHeaders: "'*'"
+        AllowHeaders: "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'"
         AllowOrigin: "'*'"
       Auth:
         AddDefaultAuthorizerToCorsPreflight: False

--- a/frontend/src/app/version.ts
+++ b/frontend/src/app/version.ts
@@ -1,3 +1,3 @@
 export const versioninfo = {
-    version: '2024-01-03-0720'
+    version: '2024-01-24-1910'
 };


### PR DESCRIPTION
Updated  'Access-Control-Allow-Headers' for OPTION calls to prevent Cross-Origin Request Warning in web browsers.